### PR TITLE
Fix header background photo

### DIFF
--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -3,7 +3,7 @@
 header {
   height: 125px;
   display: block;
-  background-image: url('../public/15background.jpg');
+  background-image: url('./public/15background.jpg');
   background-repeat: no-repeat;
   background-size: cover;
   background-position: 100% center;


### PR DESCRIPTION
On original upload, photos were not properly linked using two .. instead
of one . to access public folder.